### PR TITLE
Uppercase people's names when mauling them

### DIFF
--- a/hooks/msghooks.py
+++ b/hooks/msghooks.py
@@ -93,7 +93,7 @@ def receive_message():
             maul_ind = without_ping.index('maul')
             username = without_ping[maul_ind + 5:]
             return f"""
-                                                                   YOU CAN RUN, BUT YOU CAN'T HIDE, {username}
+                                                                   YOU CAN RUN, BUT YOU CAN'T HIDE, {username.upper()}
                                                          ___._
                                                        .'  <0>'-.._
                                                       /  /.--.____")


### PR DESCRIPTION
I know it's a near useless change, but it makes more sense for the name to also be uppercased if the rest of the message is.